### PR TITLE
fixed malformed HTML in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-	<h2 align="center">What is UI-Components/h2>
+	<h2 align="center">What is UI-Components</h2>
 	<h4 align="center">Ui-Components repository is a collection of most commonly used UI elements like navbars, loaders,carousels ,modals , cards, badges , avatars etc. Make sure to follow the guidelines of <a href="https://hacktoberfest.com/"> Hacktoberfest 2022</a> . Happy coding 😊 🎉 </h4>
 	<br/>
 	


### PR DESCRIPTION
The current version of the readme has a malformed `h2` end tag, I've fixed it in this PR.